### PR TITLE
:sparkles: Adding DependencyBuilder

### DIFF
--- a/src/DependencyBuilder.php
+++ b/src/DependencyBuilder.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Prestashop\ModuleLibMboInstaller;
+
+class DependencyBuilder
+{
+    const DEPENDENCY_FILENAME = 'ps_dependencies.json';
+
+    /**
+     * @var \ModuleCore
+     */
+    protected $module;
+
+    /**
+     * @param \ModuleCore $module
+     */
+    public function __construct($module)
+    {
+        $this->module = $module;
+    }
+
+    /**
+     * Build the dependencies data array to be given to the CDC
+     *
+     * @return array
+     */
+    public function buildDependencies()
+    {
+        $data = [
+            'module_display_name' => $this->module->displayName,
+            'module_name' => $this->module->name,
+            'module_version' => $this->module->version,
+            'ps_version' => _PS_VERSION_,
+            'php_version' => PHP_VERSION,
+            'dependencies' => [],
+        ];
+
+        $dependencyFile = $this->module->getLocalPath() . self::DEPENDENCY_FILENAME;
+        if (!file_exists($dependencyFile)) {
+            throw new \Exception(self::DEPENDENCY_FILENAME . ' file is not found in ' . $this->module->getLocalPath());
+        }
+
+        $dependenciesContent = json_decode(file_get_contents($dependencyFile), true);
+        if (json_last_error() != JSON_ERROR_NONE) {
+            throw new \Exception(self::DEPENDENCY_FILENAME . ' file may be malformatted.');
+        }
+
+        if (empty($dependenciesContent['dependencies'])) {
+            return $data;
+        }
+
+        foreach ($dependenciesContent['dependencies'] as $dependencyName => $dependencyMinVersion) {
+            $dependencyData = \DbCore::getInstance()->getRow('SELECT `id_module`, `active`, `version` FROM `' . _DB_PREFIX_ . 'module` WHERE `name` = "' . pSQL($dependencyName) . '"');
+            if (!$dependencyData) {
+                $data['dependencies'][$dependencyName] = [
+                    'min_version' => $dependencyMinVersion,
+                    'installed' => false,
+                ];
+                continue;
+            }
+            $data['dependencies'][$dependencyName] = [
+                'min_version' => $dependencyMinVersion,
+                'installed' => true,
+                'enabled' => (bool) $dependencyData['active'],
+                'current_version' => $dependencyData['version'],
+            ];
+        }
+
+        return $data;
+    }
+}


### PR DESCRIPTION
In order to correctly build the dependencies variable to instantiate the CDC, add an helper to ease the work of module devs.

So, we have to add a `ps_dependencies.json` file in the root dir of the module.

```json
{
    "dependencies": {
      "ps_mbo": "6.0.9",
      "ps_accounts": "6.0.9",
      "ps_eventbus": "6.0.9"
    }
}

```

And then, in the module : 
```php
$mboInstaller = new Prestashop\ModuleLibMboInstaller\DependencyBuilder($this);
$requiredDependencies = $mboInstaller->buildDependencies();
return $twig->render('mytpl.html.twig', [
    'requiredDependencies' => $requiredDependencies,
]);
```

And late, in the tpl
```html
<script>
    const depResolver = window.mboDepResolver;
    depResolver.init({
      dependencies: {{ requiredDependencies|json_encode|raw }},
    });
</script>
```

The `DependenciesBuilder` will build an object with several data : 
```js
{
        dependencies: {
            "module_display_name": "Example module for Prestashop",
            "module_name": "prestashopexamplemodule",
            "module_version": "1.0.0",
            "ps_version": "8.0.1",
            "php_version": "8.1.0",
            "dependencies": {
                "ps_mbo": {
                    "min_version": "6.0.9",
                    "installed": true,
                    "enabled": true,
                    "current_version": "4.3.0"
                },
                "ps_accounts": {
                    "min_version": "6.0.9",
                    "installed": false
                },
                "ps_eventbus": {
                    "min_version": "6.0.9",
                    "installed": false
                }
            }
        },
    }
```